### PR TITLE
Fix function checking for equal levels on factor columns in X and test

### DIFF
--- a/R/Xtestmerger.R
+++ b/R/Xtestmerger.R
@@ -22,8 +22,8 @@ Xtestmerger = function(X,test,inbag=NULL,y=NULL) {
     #return unmatched levels of test in X
     FUN = function(xl,tl) tl[which(is.na(match(tl,xl)))], #test levels not in x
     #for factor column, get all used levels
-    lapply(lapply(   X[factor.ind],droplevels),levels),#xl
-    lapply(lapply(test[factor.ind],droplevels),levels),#tl
+    lapply(   X[factor.ind],levels),#xl
+    lapply(test[factor.ind],levels),#tl
     SIMPLIFY = FALSE, USE.NAMES = TRUE
   )
   unmatchedLevelsCount = sapply(unmatchedTestLevels,length)


### PR DESCRIPTION
The check that both test and X will have matching levels for factor columns breaks if the levels are the same but in the test some level is not present in the data (which I can imagine happens a lot since the test set is always much smaller). By removing the droplevels function now we really compare the levels on the factors and not the appearance of levels in the data.